### PR TITLE
Let bookstack wait for mariadb container to start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     volumes:
       - bookstack_storage:/var/www/bookstack/storage
       - bookstack_public:/var/www/bookstack/public
+    depends_on:
+      - mariadb
     networks:
       - bookstack
       - bookstack_db

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -60,6 +60,8 @@ services:
     volumes:
       - bookstack_storage:/var/www/bookstack/storage
       - bookstack_public:/var/www/bookstack/public
+    depends_on:
+      - mariadb
     networks:
       - bookstack
       - bookstack_db


### PR DESCRIPTION
I had issues with mariadb not starting early enough resulting in bookstack timing out

![grafik](https://user-images.githubusercontent.com/51821028/129892357-6d5a6033-2c5a-4dd0-915c-7a344cacdefa.png)

adding a "depends_on" fixed it for me


